### PR TITLE
catching exception when reading config so it does not just fail silently

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,6 +1,6 @@
 #Grails Metadata file
 #Thu Jul 26 12:34:50 CAT 2012
-app.grails.version=2.0.0
+app.grails.version=2.1.0
 app.name=i18n-fields
 app.servlet.version=2.4
 app.version=0.3

--- a/src/groovy/i18nfields/ClassI18nalizator.groovy
+++ b/src/groovy/i18nfields/ClassI18nalizator.groovy
@@ -33,6 +33,8 @@ class ClassI18nalizator {
 	}
 
 	void transformClass() {
+		println "[i18nFields] Transforming class: ${classNode.name} for locales: ${locales}"
+		
 		configureTransformation()
 		createLocalStructures()
 		addFieldsAndAccessors()

--- a/src/groovy/i18nfields/ConfigProvider.groovy
+++ b/src/groovy/i18nfields/ConfigProvider.groovy
@@ -3,9 +3,16 @@ package i18nfields
 import grails.util.GrailsUtil
 
 class ConfigProvider {
+	
 	static final CONFIG_LOCATION = "${System.properties['user.dir']}/grails-app/conf/Config.groovy"
 
 	def getConfig() {
-		return new ConfigSlurper(GrailsUtil.environment).parse(new File(CONFIG_LOCATION).toURL())
+		try {
+			return new ConfigSlurper(GrailsUtil.environment).parse(new File(CONFIG_LOCATION).toURL())
+		} catch (Exception e) {
+			println "[i18nFields] WARNING - Exception while reading configuration, ${e}"
+			return null
+		}
 	}
+	
 }

--- a/src/groovy/i18nfields/I18nFieldsTransformation.groovy
+++ b/src/groovy/i18nfields/I18nFieldsTransformation.groovy
@@ -18,8 +18,12 @@ public class I18nFieldsTransformation implements ASTTransformation {
 	}
 
 	void visit(ASTNode[] astNodes, SourceUnit sourceUnit) {
-		if (!isValidAstNodes(astNodes))
+		println "[i18nFields] Visiting source unit ${sourceUnit.name}"
+		
+		if (!isValidAstNodes(astNodes)) {
+			println "[i18nFields] ASTNode is not valid for source unit: ${sourceUnit.name}"
 			return
+		}
 		checkForDeprecatedConfiguration()
 		ClassI18nalizator internationalizator = new ClassI18nalizator(astNodes[1], locales())
 		internationalizator.transformClass()
@@ -31,6 +35,7 @@ public class I18nFieldsTransformation implements ASTTransformation {
 
 	// TODO: Use log4j
 	private checkForDeprecatedConfiguration() {
+		println "[i18nFields] Checking for deprecated configuration"
 		if (pluginConfig."${I18nFields.I18N_FIELDS}"?.containsKey(I18nFields.DEPRECATED_LOCALES))
 			println "[i18nFields] WARNING - Configuration is using a deprecated locale list definition (i18n_langs). Change it for 'locales' as soon as possible"
 		if (pluginConfig."${I18nFields.I18N_FIELDS}"?.containsKey(I18nFields.DEPRECATED_EXTRA_LOCALES))


### PR DESCRIPTION
When an exception is thrown while the config file is read, the plugin just fails silently, with this patch, it catches the exception and displays it to the user.

To test, add some garbage in the config file Config.groovy, for example a invalid import.
